### PR TITLE
Fix `history/createBrowserHistory` warning

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -1,4 +1,4 @@
-import createHistory from 'history/createBrowserHistory';
+import {createBrowserHistory as createHistory} from 'history';
 import {
   pageTransitionEvent,
   pageTransitionTime,


### PR DESCRIPTION
Due to the warning:  
Warning: Please use `require("history").createBrowserHistory` instead of `require("history/createBrowserHistory")`. Support for the latter will be removed in the next major release.